### PR TITLE
[28954] Set hostname/ssl in configure when apache skipped

### DIFF
--- a/bin/configure
+++ b/bin/configure
@@ -1,3 +1,63 @@
 #!/bin/bash
 
-exit 0
+set -e
+
+. "${INSTALLER_DIR}/wizard"
+
+input_start() {
+  local server_autoinstall=$(wiz_get "server/autoinstall" || echo "skip")
+  if [ "$server_autoinstall" = "skip" ] ; then
+    STATE="input_hostname"
+  else
+    STATE="done"
+  fi
+}
+
+input_hostname_params() {
+  local default_hostname=$(hostname -f 2>/dev/null || hostname || echo "example.com")
+
+  if ! wiz_get "server/hostname" &>/dev/null ; then
+    wiz_set "server/hostname" "$default_hostname"
+    wiz_unseen "server/hostname"
+  fi
+
+  wiz_put "server/hostname"
+  if wiz_ask ; then
+    STATE="input_protocol"
+  else
+    STATE="start"
+  fi
+}
+
+input_protocol_params() {
+  wiz_put "server/ssl"
+  if wiz_ask ; then
+    STATE="done"
+  else
+    STATE="input_hostname"
+  fi
+}
+
+state_machine() {
+  case "$1" in
+    "start")
+      input_start
+      ;;
+    "input_hostname")
+      input_hostname_params
+      ;;
+    "input_protocol")
+      input_protocol_params
+      ;;
+    "done")
+      echo "DONE"
+      break
+      ;;
+    *)
+      echo "invalid state ${STATE}"
+      break
+      ;;
+  esac
+}
+
+wizard "start"

--- a/templates
+++ b/templates
@@ -1,0 +1,15 @@
+Template: server/ssl
+Type: select
+Choices: no, yes
+Translations: No, Yes
+Default: no
+Description: Do you use SSL to access _APP_NAME_
+ Enabling SSL makes your _APP_NAME_ installation more secure.
+ .
+ If you choose YES, the application server will only respond to https. You need to manually configure SSL certificates for your web server.
+
+Template: server/hostname
+Type: string
+Default: www.example.com
+Description: Your fully qualified domain name:
+ Enter the fully qualified domain name (FQDN), where this server can be reached.


### PR DESCRIPTION
When apache installation was skipped, there is no wizard to ask for hostname and protocol of OpenProject.

When the apache2 configuration is skipped, these two values remain. With this change, the wizards will be shown later again for server/hostname (Setting.host_name) and server/ssl (Setting.protocol). Both are assigned in the packger.rake: https://github.com/opf/openproject/blob/dev/lib/tasks/packager.rake#L66

https://community.openproject.com/wp/28954